### PR TITLE
Update OTPTextField.swift

### DIFF
--- a/Roshetta/Components/View/OTPTextField.swift
+++ b/Roshetta/Components/View/OTPTextField.swift
@@ -34,13 +34,13 @@ struct OTPTextField: View {
                     .multilineTextAlignment(.center)
                     .focused($fieldFoucus, equals: index)
                     .tag(index)
-                    .onChange(of: enterValue[index]) { newValue in
+                    .onChange(of: enterValue[index]) { _, newValue in
                         if enterValue[index].count > 1 {
                             let currentValue = Array(enterValue[index])
                             if currentValue[0] == Character(oldValue) {
-                                enterValue[index] =  String(enterValue[index].suffix(1))
+                                enterValue[index] = String(enterValue[index].suffix(1))
                             } else {
-                                enterValue[index] =  String(enterValue[index].prefix(1))
+                                enterValue[index] = String(enterValue[index].prefix(1))
                             }
                         }
                         if !newValue.isEmpty {
@@ -53,13 +53,13 @@ struct OTPTextField: View {
                             fieldFoucus = (fieldFoucus ?? 0) - 1
                         }
                     }
+
+
             }
         }
     }
 }
 
-struct OTPTextField_Previews: PreviewProvider {
-    static var previews: some View {
-        OTPTextField(numberOfFields: 6, enterValue: .constant(["", "", "", "", "", ""]))
-    }
+#Preview {
+     OTPTextField(numberOfFields: 6, enterValue: .constant(["", "", "", "", "", ""]))
 }


### PR DESCRIPTION
The only thing I've updated is related to iOS 17 , 2 Points 

1- onChange have been depreciated  and takes 0 or 2 parameters which I've changed 

2- second the Macro #Preview .

only take it if you're upgrading to ios17